### PR TITLE
Added nonfunctional creative-mode-style screen

### DIFF
--- a/assets/ui/blocks.ui
+++ b/assets/ui/blocks.ui
@@ -1,0 +1,46 @@
+{
+    "type": "BlocksScreen",
+    "contents":{
+        "type": "migLayout",
+        "colConstraints": "[min][grow, fill][min][min][min]",
+        "rowConstraints": "[min][grow, fill]",
+        "contents": [
+            {
+                "type": "UILabel",
+                "text": "Search For: ",
+                "layoutInfo" : {"cc": ""}
+            },
+
+            {
+                "type": "UIText",
+                "text": "",
+                "layoutInfo" : {"cc": "growx"},
+                "multiline": false
+            },
+
+            {
+                "type": "UILabel",
+                "text": "Simultaneous Search",
+                "layoutInfo" : {"cc": ""}
+            },
+
+            {
+                "type": "UICheckbox",
+                "layoutInfo" : {"cc": ""}
+            },
+
+            {
+                "type": "UIButton",
+                "text": "Search",
+                "layoutInfo" : {"cc": "wrap"}
+            },
+
+            {
+                "type": "InventoryGrid",
+                "id": "inv",
+                "maxHorizontalCells": 10,
+                "layoutInfo" : {"cc": "span 5", "layoutConstraints": ""}
+            }
+        ]
+    }
+}

--- a/src/main/java/org/terasology/nui/BlocksScreen.java
+++ b/src/main/java/org/terasology/nui/BlocksScreen.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.nui;
+
+import org.terasology.rendering.nui.CoreScreenLayer;
+
+/**
+ * This class provides the Java side of the Block Selection Screen, which offers functionality similar to creative
+ * mode in Minecraft in that it allows any blocks or items to be spawned via a GUI alternative to the /give command. It
+ * also allows the searching of all available blocks and items.
+ */
+public class BlocksScreen extends CoreScreenLayer{
+
+    @Override
+    public void initialise(){
+        //TODO: Get list of items and alphabatize names
+        //TODO: Add list of items (alphabatized or otherwise) to Inventory view (after inventoryview is fixed)
+        //TODO: Use binary search on alphabatized list of items for efficient searches (in another method called when search button is pressed)
+    }
+
+}


### PR DESCRIPTION
This is done for the Google Code-in Task. I was originally planning on fully implementing the screen, but, due to the lack of documentation (I asked in IRC as well) on showing an inventory in NUI, I am submitting this task to be able to move on to the next task. I have, however, outlined a method for efficient lookups of blocks by name in the code that I recommend be implemented at some point in the future since Minecraft mod packs with many have performance issues with creative mode menu searches and Terasology would, ideally, avoid that.