### PR TITLE
Fix format in Underglaze.block

### DIFF
--- a/assets/blocks/Underglaze.block
+++ b/assets/blocks/Underglaze.block
@@ -4,7 +4,7 @@
     "categories" : ["Brick"],
     "template" : false,
     "shape" : "engine:cube",
-    "hardness": 50    
+    "hardness": 50,    
     "attachmentAllowed" : true,
     "supportRequired" : false,
     "penetrable" : false,


### PR DESCRIPTION
This fixes MovingBlocks/Terasology#2853.

The culprit was a missing comma in the JSON file. The command executes normally now (and as a consequence, the actual Sample:Underglaze block is now usable too).