### PR TITLE
Add UI for basic CPU info

### DIFF
--- a/assets/ui/cpuInfoScreen.ui
+++ b/assets/ui/cpuInfoScreen.ui
@@ -1,0 +1,58 @@
+{
+  "type": "CpuInfoScreen",
+  "contents": {
+    "type": "relativeLayout",
+    "contents": [
+      {
+        "type": "UIBox",
+        "layoutInfo": {
+          "width": 300,
+          "height": 300,
+          "position-horizontal-center": {},
+          "position-vertical-center": {}
+        },
+        "content": {
+          "type": "relativeLayout",
+          "contents": [
+            {
+              "type": "UILabel",
+              "id": "cpuInfoLabel",
+              "text": "CPU Info",
+              "layoutInfo": {
+                "use-content-width": true,
+                "position-horizontal-center": {},
+                "height": 30
+              }
+            },
+            {
+              "type": "UIText",
+              "text": "",
+              "id": "infoArea",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "cpuInfoLabel",
+                  "target": "BOTTOM"
+                },
+                "position-bottom": {
+                  "widget": "updateInfoButton",
+                  "target": "TOP"
+                }
+              },
+              "multiline": true,
+              "readOnly": true
+            },
+            {
+              "type": "UIButton",
+              "id": "updateInfoButton",
+              "text": "Update Information",
+              "layoutInfo": {
+                "use-content-height": true,
+                "position-bottom": {}
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/main/java/org/terasology/nui/CpuInfoScreen.java
+++ b/src/main/java/org/terasology/nui/CpuInfoScreen.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.nui;
+
+import org.terasology.engine.Time;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.rendering.nui.widgets.UIText;
+
+public class CpuInfoScreen extends CoreScreenLayer {
+    private UIText infoArea;
+    private UIButton updateInfoButton;
+
+    @In
+    private Time time;
+
+    @Override
+    public void initialise() {
+        infoArea = find("infoArea", UIText.class);
+        updateInfoButton = find("updateInfoButton", UIButton.class);
+
+        if (updateInfoButton != null) {
+            updateInfoButton.subscribe(button -> {
+                int nCores = Runtime.getRuntime().availableProcessors();
+
+                // Get current CPU usage
+
+
+                infoArea.setText(String.format("Welcome to the CPU info screen!%n" +
+                        "There are currently %d CPU cores available to Terasology.%n" +
+                        "As for temperature... well, your computer is on. We know that much.%n" +
+                        "(If you can figure out a way to measure core temp in Java, submit a pull request on GitHub!)",
+                        nCores
+                ));
+            });
+        }
+    }
+}


### PR DESCRIPTION
Based off of the NUI tutorial. Only shows core count, as CPU temp is basically impossible without a LOT of long-term maintenance, and CPU usage relies on the javax package - which may be too expensive/ not portable enough for Terasology.

For a Google Code-In 2017 task on developing a simple interface screen with NUI.