### PR TITLE
Add Block Family Count Screen

### DIFF
--- a/assets/ui/blockFamilyCountScreen.ui
+++ b/assets/ui/blockFamilyCountScreen.ui
@@ -1,0 +1,8 @@
+{
+    "type": "BlockFamilyCountScreen",
+    "contents": {
+        "type": "UILabel",
+        "id": "blockFamilyCountLabel",
+        "text": ""
+    }
+}

--- a/src/main/java/org/terasology/nui/BlockFamilyCountScreen.java
+++ b/src/main/java/org/terasology/nui/BlockFamilyCountScreen.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.nui;
+
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.widgets.UILabel;
+import org.terasology.world.block.BlockManager;
+
+public class BlockFamilyCountScreen extends CoreScreenLayer {
+    private UILabel blockFamilyCountLabel;
+
+    @In
+    BlockManager blockManager;
+
+    @Override
+    public void initialise() {
+        blockFamilyCountLabel = find("blockFamilyCountLabel", UILabel.class);
+
+        blockFamilyCountLabel.setText("Number of Registered Block Families: " + blockManager.getBlockFamilyCount());
+    }
+}


### PR DESCRIPTION
![screenshot_20180102_220035](https://user-images.githubusercontent.com/8018181/34491236-b30b61bc-f008-11e7-8434-468c814c1217.png)

Shows the number of registered block families in a small little label.

```
showScreen blockFamilyCountScreen
```
