### PR TITLE
FortuneTeller radial sample

### DIFF
--- a/assets/ui/fortuneTeller.ui
+++ b/assets/ui/fortuneTeller.ui
@@ -1,0 +1,32 @@
+{
+  "type": "FortuneTeller",
+  "contents": {
+    "type": "relativeLayout",
+    "contents": [
+      {
+        "type": "UIRadialRing",
+        "id": "radialMenu",
+        "layoutInfo": {
+          "width": 600,
+          "height": 600,
+          "position-vertical-center": {},
+          "position-horizontal-center": {}
+        },
+        "sections": []
+      },
+      {
+        "type": "UIText",
+        "text": "Choose your fortune...",
+        "id": "infoArea",
+        "layoutInfo": {
+          "position-top": {
+            "widget": "radialMenu",
+            "target": "BOTTOM"
+          }
+        },
+        "multiline": true,
+        "readOnly": true
+      }
+    ]
+  }
+}

--- a/src/main/java/org/terasology/nui/FortuneTeller.java
+++ b/src/main/java/org/terasology/nui/FortuneTeller.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.nui;
+
+
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.widgets.UIRadialRing;
+import org.terasology.rendering.nui.widgets.UIRadialSection;
+import org.terasology.rendering.nui.widgets.UIText;
+
+import java.util.LinkedList;
+import java.util.List;
+
+
+public class FortuneTeller extends CoreScreenLayer {
+    private UIText infoArea;
+    private UIRadialRing radialRing;
+
+    private final String[] fortunes = new String[] {
+            "You will discover a new block!",
+            "A radial menu event will trigger!",
+            "A bugfix will be released!",
+            "You will be underwhelmed by this fortune!",
+            "You will click another radial button!"
+    };
+
+    @Override
+    public void initialise() {
+        infoArea = find("infoArea", UIText.class);
+        radialRing = find("radialMenu", UIRadialRing.class);
+
+        List<UIRadialSection> newSections = new LinkedList<>();
+
+        for (int i = 0; i < fortunes.length; i++) {
+            UIRadialSection newSection = new UIRadialSection();
+            newSection.setText(Integer.toString(i));
+
+            newSections.add(newSection);
+        }
+
+        radialRing.setSections(newSections);
+
+        if (radialRing != null) {
+            for (int i = 0; i < 5; i++) {
+                final int index = i;
+                radialRing.subscribe(i, widget -> infoArea.setText(fortunes[index]));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
For GCI, adds a radial "fortune teller" as a sample for a radial menu with runtime-generated buttons.

A real use for a radial widget like this could be the start/action menu for TS gamepad compatibility. Many modules in TS are build with PC in mind, and use keybindings for all of their actions. A gamepad player may not have access to a keyboard, so all keybindings need to fit on a controller, which only has enough individual buttons for core game actions. External modules must be able to add their actions to a core "action menu" as all gamepad buttons should be reserved for the engine and rarely used by a separate module. The engine should have some API allowing module developers to register their own actions to the radial menu, instead of only adding their own keybinds.

`showscreen fortuneteller`

![preview](https://vgy.me/ZSkA6H.png)