### PR TITLE
Add screen that displays text from registered providers

### DIFF
--- a/assets/ui/ListenerScreen.ui
+++ b/assets/ui/ListenerScreen.ui
@@ -1,0 +1,58 @@
+{
+  "type": "ListenerScreen",
+  "contents": {
+    "type": "relativeLayout",
+    "contents": [
+      {
+        "type": "UIBox",
+        "layoutInfo": {
+          "width": 300,
+          "height": 300,
+          "position-horizontal-center": {},
+          "position-vertical-center": {}
+        },
+        "content": {
+          "type": "relativeLayout",
+          "contents": [
+            {
+              "type": "UILabel",
+              "id": "listenerLabel",
+              "text": "Registered Info",
+              "layoutInfo": {
+                "use-content-width": true,
+                "position-horizontal-center": {},
+                "height": 30
+              }
+            },
+            {
+              "type": "UIText",
+              "id": "listenerText",
+              "text": "",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "listenerLabel",
+                  "target": "BOTTOM"
+                },
+                "position-bottom": {
+                  "widget": "listenerButton",
+                  "target": "TOP"
+                }
+              },
+              "multiline": true,
+              "readOnly": true
+            },
+            {
+              "type": "UIButton",
+              "id": "listenerButton",
+              "text": "Update",
+              "layoutInfo": {
+                "use-content-height": true,
+                "position-bottom": {}
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/assets/ui/internal_TestListenerScreen.ui
+++ b/assets/ui/internal_TestListenerScreen.ui
@@ -1,0 +1,58 @@
+{
+  "type": "TestListenerScreen",
+  "contents": {
+    "type": "relativeLayout",
+    "contents": [
+      {
+        "type": "UIBox",
+        "layoutInfo": {
+          "width": 300,
+          "height": 300,
+          "position-horizontal-center": {},
+          "position-vertical-center": {}
+        },
+        "content": {
+          "type": "relativeLayout",
+          "contents": [
+            {
+              "type": "UILabel",
+              "id": "listenerLabel",
+              "text": "Registered Info",
+              "layoutInfo": {
+                "use-content-width": true,
+                "position-horizontal-center": {},
+                "height": 30
+              }
+            },
+            {
+              "type": "UIText",
+              "id": "listenerText",
+              "text": "",
+              "layoutInfo": {
+                "position-top": {
+                  "widget": "listenerLabel",
+                  "target": "BOTTOM"
+                },
+                "position-bottom": {
+                  "widget": "listenerButton",
+                  "target": "TOP"
+                }
+              },
+              "multiline": true,
+              "readOnly": true
+            },
+            {
+              "type": "UIButton",
+              "id": "listenerButton",
+              "text": "Update",
+              "layoutInfo": {
+                "use-content-height": true,
+                "position-bottom": {}
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/main/java/org/terasology/nui/ListenerScreen.java
+++ b/src/main/java/org/terasology/nui/ListenerScreen.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.nui;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.widgets.UIButton;
+import org.terasology.rendering.nui.widgets.UIText;
+
+import java.util.ArrayList;
+
+public class ListenerScreen extends CoreScreenLayer {
+    private UIText text;
+    private UIButton button;
+    private static ArrayList<ListenerScreenTextProvider> providers = new ArrayList<>();
+
+    @Override
+    public void initialise() {
+        text = find("listenerText", UIText.class);
+        button = find("listenerButton", UIButton.class);
+
+        if (button != null) {
+            button.subscribe(w -> {
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < providers.size(); i++) {
+                    sb.append(providers.get(i).getText());
+                    if (i < providers.size() - 1) {
+                        sb.append("\n");
+                    }
+                }
+                text.setText(sb.toString());
+            });
+        }
+    }
+
+    public static void registerProvider(ListenerScreenTextProvider provider) {
+        providers.add(provider);
+    }
+}

--- a/src/main/java/org/terasology/nui/ListenerScreen.java
+++ b/src/main/java/org/terasology/nui/ListenerScreen.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.nui;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.widgets.UIButton;
 import org.terasology.rendering.nui.widgets.UIText;
@@ -25,13 +23,24 @@ import java.util.ArrayList;
 
 public class ListenerScreen extends CoreScreenLayer {
     private UIText text;
-    private UIButton button;
-    private static ArrayList<ListenerScreenTextProvider> providers = new ArrayList<>();
+
+    private static ListenerScreen instance;
+    private ArrayList<ListenerScreenTextProvider> providers = new ArrayList<>();
+
+    public ListenerScreen() {
+        this(true);
+    }
+
+    private ListenerScreen(boolean singleton) {
+        if(singleton) {
+            instance = this;
+        }
+    }
 
     @Override
     public void initialise() {
         text = find("listenerText", UIText.class);
-        button = find("listenerButton", UIButton.class);
+        UIButton button = find("listenerButton", UIButton.class);
 
         if (button != null) {
             button.subscribe(w -> {
@@ -48,6 +57,6 @@ public class ListenerScreen extends CoreScreenLayer {
     }
 
     public static void registerProvider(ListenerScreenTextProvider provider) {
-        providers.add(provider);
+        instance.providers.add(provider);
     }
 }

--- a/src/main/java/org/terasology/nui/ListenerScreenTextProvider.java
+++ b/src/main/java/org/terasology/nui/ListenerScreenTextProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.nui;
+
+public interface ListenerScreenTextProvider {
+    String getText();
+}

--- a/src/main/java/org/terasology/nui/internal/TestListenerScreen.java
+++ b/src/main/java/org/terasology/nui/internal/TestListenerScreen.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.nui.internal;
+
+import org.terasology.nui.ListenerScreen;
+
+public class TestListenerScreen extends ListenerScreen {
+    @Override
+    public void initialise() {
+        super.initialise();
+
+        registerProvider(new TestListenerScreenTextProvider());
+        registerProvider(new TestListenerScreenTextProvider());
+    }
+}

--- a/src/main/java/org/terasology/nui/internal/TestListenerScreenTextProvider.java
+++ b/src/main/java/org/terasology/nui/internal/TestListenerScreenTextProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.nui.internal;
+
+import org.terasology.nui.ListenerScreenTextProvider;
+
+public class TestListenerScreenTextProvider implements ListenerScreenTextProvider {
+    private int count;
+
+    @Override
+    public String getText() {
+        return String.valueOf(++count);
+    }
+}


### PR DESCRIPTION
### Contains

A screen that allows providers to be registered to it. The providers provide a line of text. When the screen is updated, providers will be accessed and the received lines will be displayed together in the text area.

### How to test

A test implementation with two identical providers counting the number of times the screen has been updated is available with the name `internal_TestListenerScreen`. Ensure also that the production implementation has the correct layout.

### Outstanding before merging
- [ ] Fully separate test and production code