### PR TITLE
Modified the calculator UI to follow a more standard format and miscellaneous fixes.

### DIFF
--- a/assets/ui/calculator.ui
+++ b/assets/ui/calculator.ui
@@ -57,7 +57,7 @@
                                 "id": "button1",
                                 "text": "1",
                                 "layoutInfo": {
-                                    "cc": "cell 0 0"
+                                    "cc": "cell 0 2"
                                 }
                             },
                             {
@@ -65,7 +65,7 @@
                                 "id": "button2",
                                 "text": "2",
                                 "layoutInfo": {
-                                    "cc": "cell 1 0"
+                                    "cc": "cell 1 2"
                                 }
                             },
                             {
@@ -73,7 +73,7 @@
                                 "id": "button3",
                                 "text": "3",
                                 "layoutInfo": {
-                                    "cc": "cell 2 0"
+                                    "cc": "cell 2 2"
                                 }
                             },
                             {
@@ -105,7 +105,7 @@
                                 "id": "button7",
                                 "text": "7",
                                 "layoutInfo": {
-                                    "cc": "cell 0 2"
+                                    "cc": "cell 0 0"
                                 }
                             },
                             {
@@ -113,7 +113,7 @@
                                 "id": "button8",
                                 "text": "8",
                                 "layoutInfo": {
-                                    "cc": "cell 1 2"
+                                    "cc": "cell 1 0"
                                 }
                             },
                             {
@@ -121,7 +121,7 @@
                                 "id": "button9",
                                 "text": "9",
                                 "layoutInfo": {
-                                    "cc": "cell 2 2"
+                                    "cc": "cell 2 0"
                                 }
                             },
                             {
@@ -137,7 +137,7 @@
                                 "id": "buttonEquals",
                                 "text": "=",
                                 "layoutInfo": {
-                                    "cc": "cell 2 3"
+                                    "cc": "cell 4 3"
                                 }
                             },
                             {
@@ -145,7 +145,7 @@
                                 "id": "buttonAdd",
                                 "text": "+",
                                 "layoutInfo": {
-                                    "cc": "cell 3 0"
+                                    "cc": "cell 3 2"
                                 }
                             },
                             {
@@ -153,7 +153,7 @@
                                 "id": "buttonSubtract",
                                 "text": "-",
                                 "layoutInfo": {
-                                    "cc": "cell 3 1"
+                                    "cc": "cell 4 2"
                                 }
                             },
                             {
@@ -161,7 +161,7 @@
                                 "id": "buttonMultiply",
                                 "text": "*",
                                 "layoutInfo": {
-                                    "cc": "cell 3 2"
+                                    "cc": "cell 3 1"
                                 }
                             },
                             {
@@ -169,7 +169,7 @@
                                 "id": "buttonDivide",
                                 "text": "/",
                                 "layoutInfo": {
-                                    "cc": "cell 3 3"
+                                    "cc": "cell 4 1"
                                 }
                             },
                             {
@@ -193,7 +193,7 @@
                                 "id": "buttonBack",
                                 "text": "Delete",
                                 "layoutInfo": {
-                                    "cc": "cell 4 1"
+                                    "cc": "cell 3 0"
                                 }
                             },
                             {
@@ -201,7 +201,7 @@
                                 "id": "buttonLeftBracket",
                                 "text": "(",
                                 "layoutInfo": {
-                                    "cc": "cell 4 2"
+                                    "cc": "cell 2 3"
                                 }
                             },
                             {
@@ -209,7 +209,7 @@
                                 "id": "buttonRightBracket",
                                 "text": ")",
                                 "layoutInfo": {
-                                    "cc": "cell 4 3"
+                                    "cc": "cell 3 3"
                                 }
                             }]
                         }


### PR DESCRIPTION
# Description
This pull request modifies the calculator's numerical layout to a more conventional one. It also allows the calculator to start a new calculation by pressing a numeric button (0-9) after the equals button. 
This fixes the remaining issues with #103.
## Changes made
- The calculator UI screen now displays the number buttons in the correct format.
- The plus and minus, multiply and divide, left and right brackets and delete and clear buttons have been put in pairs next to each other.
- The equals button is now located in the bottom-right corner of the calculator.
- When pressing either a numeric, bracket or dot button after pressing the equals buttons, a new calculation should be started,
- The code has been split into several methods, with the actual calculation still being done in a single method.
## Image
![calculatoruiimproved](https://user-images.githubusercontent.com/24301287/48665616-c7f69a00-eaa9-11e8-9a3d-721180003988.JPG)



